### PR TITLE
Update LWJGL3 version in minecraft-runtime-1.13

### DIFF
--- a/minecraft-runtime-1.13
+++ b/minecraft-runtime-1.13
@@ -21,7 +21,7 @@ build_classpath() {
     for p in ${1}
     do
         case "${p}" in
-            *lwjgl-3.1.6.jar)
+            *lwjgl-3.*.jar)
 		echo set $p = ${LWJGL_OVRD}
 		cp="${cp}:${LWJGL_OVRD}"
 		;;


### PR DESCRIPTION
Updated the version in the runtime executable to make it match the version built by `build.sh`.  This is what it took for it to run 1.15.2 on my system.